### PR TITLE
Add /builds page

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -29,10 +29,6 @@ pygmentsUseClassic=true
       pre = "<i class='fa fa-comments-o'></i>"
       weight = 230
       url = "https://discourse.speckle.works/"
-  [[menu.main]]
-      name = "Builds"
-      weight = 400
-      url = "/builds/"
 
 
 [params]

--- a/config.toml
+++ b/config.toml
@@ -29,6 +29,10 @@ pygmentsUseClassic=true
       pre = "<i class='fa fa-comments-o'></i>"
       weight = 230
       url = "https://discourse.speckle.works/"
+  [[menu.main]]
+      name = "Builds"
+      weight = 400
+      url = "/builds/"
 
 
 [params]

--- a/content/builds.md
+++ b/content/builds.md
@@ -4,6 +4,7 @@ title = "Builds"
 description = "Speckle nightly builds"
 type = "page"
 layout = "about"
+menu = "main"
 +++
 
 Here's one we built earlier.

--- a/content/builds.md
+++ b/content/builds.md
@@ -1,0 +1,15 @@
++++
+date = "2018-06-03T08:45:40+0100"
+title = "Builds"
+description = "Speckle nightly builds"
+type = "page"
+layout = "about"
++++
+
+Here's one we built earlier.
+
+## [SpeckleRhino](https://github.com/speckleworks/SpeckleRhino)
+
+<div id="listing"><pre>Loading...</pre></div>
+
+<script async defer src="/js/builds.js"></script>

--- a/content/builds.md
+++ b/content/builds.md
@@ -8,8 +8,16 @@ layout = "about"
 
 Here's one we built earlier.
 
+## [SpeckleCore](https://github.com/speckleworks/SpeckleCore)
+
+<div id="listingSpeckleCore"><pre>Loading...</pre></div>
+
 ## [SpeckleRhino](https://github.com/speckleworks/SpeckleRhino)
 
-<div id="listing"><pre>Loading...</pre></div>
+<div id="listingSpeckleRhino"><pre>Loading...</pre></div>
+
+## [SpeckleDynamo](https://github.com/speckleworks/SpeckleDynamo)
+
+_Coming soon!_
 
 <script async defer src="/js/builds.js"></script>

--- a/themes/speckleworks/static/css/main.css
+++ b/themes/speckleworks/static/css/main.css
@@ -592,6 +592,10 @@ pre {
   font-family: monospace !important;
 }
 
+pre a {
+  font-family: monospace;
+}
+
 code {
   box-sizing: border-box;
   padding: 3px;

--- a/themes/speckleworks/static/js/builds.js
+++ b/themes/speckleworks/static/js/builds.js
@@ -50,7 +50,7 @@ function populate(nwo) {
 
     // item.artifact = 'specklerhino.rhi'; // use generic download icon instead
     // NOTE: don't use padRightUrl() for glyph - it gets truncated which causes issues
-    item.artifact = "<i class='fa fa-download'></i>";
+    item.artifact = "<i class='fa fa-file-archive-o'></i>";
     // var artifact_url = `${api_url}/buildJobs/${jobId}/artifacts/specklerhino.rhi`;
     // use generic url to save api calls
     var artifact_url = `https://ci.appveyor.com/project/${nwo}/build/${build.version}/artifacts`;

--- a/themes/speckleworks/static/js/builds.js
+++ b/themes/speckleworks/static/js/builds.js
@@ -1,0 +1,136 @@
+// based on https://github.com/rufuspollock/s3-bucket-listing
+
+// document.getElementById('listing').innerHTML = "<pre>Loading...</pre>";
+
+var nwo = "speckleworks/SpeckleRhino";
+
+var api_url = "https://ci.appveyor.com/api/";
+
+var url = `${api_url}/projects/${nwo}/history?recordsNumber=10&branch=master`;
+
+var xhr = new XMLHttpRequest();
+xhr.open('get', url, false);
+xhr.send(null);
+
+var json = JSON.parse(xhr.response);
+
+var items = [];
+for (var i = 0; i < json.builds.length; i++) {
+  var build = json.builds[i]
+
+  if (build.status != 'success') {
+    continue;
+  }
+
+  var url = `${api_url}/projects/${nwo}/build/${build.version}`;
+  xhr.open('get', url, false);
+  xhr.send(null);
+
+  var build_json = JSON.parse(xhr.response);
+
+  var jobId = build_json.build.jobs[0].jobId;
+
+
+  var item = {};
+
+  var date = Date.parse(build.finished);
+  var date = new Date(build.finished);
+
+  item.date = date.toISOString();
+  item.number = build.version;
+  item.ci_url = `https://ci.appveyor.com/project/${nwo}/build/${build.version}`;
+
+  item.sha = build.commitId;
+  item.sha_short = item.sha.slice(0,7);
+  item.github_url = `https://github.com/${nwo}/commit/${item.sha}`;
+  // item.message = build.message;
+
+  item.artifact = 'specklerhino.rhi';
+  var artifact_url = `${api_url}/buildJobs/${jobId}/artifacts/specklerhino.rhi`;
+  item.artifact_url = artifact_url;
+
+  item.ref = build.branch;
+  if (build.pullRequestId != null) {
+    item.ref = '#' + build.pullRequestId;
+    item.ref_url = `https://github.com/${nwo}/pull/${build.pullRequestId}`;
+  }
+
+  items.push(item);
+}
+
+document.getElementById('listing').innerHTML = '<pre>' + prepareTable(items) + '</pre>';
+
+function prepareTable(items) {
+  // items is object like:
+  // [
+  //   {
+  //      number: ..
+  //      ref: ..
+  //      sha: ..
+  //      sha_short: ..
+  //      github_url: ..
+  //      artifact: ..
+  //      artifact_url: ..
+  //   },
+  //   ...
+  // ]
+  var cols = [ 29, 10, 12, 25, 16 ];
+  var content = [];
+  content.push(padRight('Date', cols[0]) + padRight('Number', cols[1]) + padRight('SHA', cols[2]) + padRight('Artifact', cols[3]) + 'Branch\n');
+  content.push(new Array(cols[0] + cols[1] + cols[2] + cols[3] + cols[4] + 4).join('-') + '\n');
+
+
+  // jQuery.each(items, function(idx, item) {
+  items.forEach(function(item) {
+    var row = renderRow(item, cols);
+    content.push(row + '\n');
+  });
+
+  return content.join('');
+}
+
+function renderRow(item, cols) {
+  var row = '';
+  row += padRight(item.date, cols[0]);
+  row += padRightUrl(item.number, item.ci_url, cols[1]);
+  row += padRightUrl(item.sha_short, item.github_url, cols[2], item.message);
+  row += padRightUrl(item.artifact, item.artifact_url, cols[3]);
+  if (item.ref_url != null) {
+    row += padRightUrl(item.ref, item.ref_url, cols[4]);
+  } else {
+    row += padRight(item.ref, cols[4]);
+  }
+  // row += '  ';
+  return row;
+}
+
+function padRight(padString, length) {
+  var str = String(padString).slice(0, length-3);
+  if (padString.length > str.length) {
+    str += '...';
+  }
+  while (str.length < length) {
+    str = str + ' ';
+  }
+  return str;
+}
+
+function padRightUrl(padString, padUrl, length, title) {
+  var str = String(padString).slice(0, length-3);
+  if (padString.length > str.length) {
+    str += '...';
+  }
+  var len = str.length;
+  if (title) {
+    title = ' title="' + title + '" ';
+  }
+  else {
+    title = '';
+  }
+  str = '<a href="' + padUrl + '"' + title + '>' + str + '</a>'
+  while (len < length) {
+    str = str + ' ';
+    len++;
+  }
+  return str;
+}


### PR DESCRIPTION
Going back to the [slack discussion](https://speckle-works.slack.com/archives/C4U5UM3EY/p1526998306000669) about making build artifacts more accessible...

First pass at porting the script I wrote for https://pearswj.co.uk/builds/compat from travis-ci to AppVeyor. Displays latest builds for SpeckleRhino by pulling data from the AppVeyor API.

A few thoughts/caveats...

* It's a little slow because the API requires a call per `build` to get the `jobId` for the artifact download links.
  * Could be sped up by just linking to the [artifacts tab on the build page](https://ci.appveyor.com/project/SpeckleWorks/specklerhino/build/367/artifacts). (Might be necessary if/when this page shows builds from other projects too.)
  * AppVeyor now has a [3 month artifact retention policy](https://www.appveyor.com/blog/2018/05/24/artifacts-retention-policy/), so we might consider pushing build artifacts elsewhere (again, saving many API calls to get the direct download link for artifacts).
* I've included the latest 10 builds from the `master` branch and pull requests only.
* It doesn't have to be styled in this monospaced, tabular layout.

Open to suggestions!

![screen shot 2018-06-03 at 10 26 18](https://user-images.githubusercontent.com/121068/40885195-7c55c5d0-6719-11e8-9671-2787223ac183.png)

/cc @didimitrie @fraguada @Eckart-S 